### PR TITLE
Fix insertion of non ascii characters in tmp buffer.

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -973,15 +973,14 @@ start revision."
     (with-temp-file tmpfile
       (insert content))))
 
-(defsubst git-gutter:original-file-content (file)
+(defun git-gutter:original-file-content-p (file)
   (with-temp-buffer
-    (when (zerop (process-file "git" nil t nil "show" (concat ":" file)))
-      (buffer-substring-no-properties (point-min) (point-max)))))
+    (zerop (process-file "git" nil t nil "show" (concat ":" file)))))
 
 (defun git-gutter:write-original-content (tmpfile filename)
-  (git-gutter:awhen (git-gutter:original-file-content filename)
+  (when (git-gutter:original-file-content-p filename)
     (with-temp-file tmpfile
-      (insert it)
+      (insert-file-contents filename)
       t)))
 
 (defsubst git-gutter:start-raw-diff-process (proc-buf original now)


### PR DESCRIPTION
- git-gutter.el (git-gutter:original-file-content-p):
  Renamed from git-gutter:original-file-content and transformed in predicate
  that return non-nil when git process exit with 0 status.
  (git-gutter:write-original-content): Use it and use insert-file-contents.
