### PR TITLE
Allow custom `signs' to inherit propertized face values

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -382,6 +382,10 @@ gutter information of other windows."
                       face 'git-gutter:modified))
       (deleted (setq sign git-gutter:deleted-sign
                      face 'git-gutter:deleted)))
+    (when (get-text-property 0 'face sign)
+      (setq face (append
+                  (get-text-property 0 'face sign)
+                  `(:inherit ,face))))
     (propertize sign 'face face)))
 
 (defsubst git-gutter:linum-get-overlay (pos)


### PR DESCRIPTION
Addresses domtronn/all-the-icons.el#53

This would allow users to do something along the lines of
```el
(setq git-gutter:added-sign
      (propertize
       ;; Whatever sign you want e.g.
       (all-the-icons-octicon "diff-added")
       'face `( :family ,(all-the-icons-octicon-family)
                :height 0.8 )))
```