### PR TITLE
Fix error when git cmd output is not a number

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -208,9 +208,12 @@ gutter information of other windows."
 (defun git-gutter:in-git-repository-p ()
   (when (executable-find "git")
     (with-temp-buffer
-      (when (zerop (git-gutter:execute-command "git" t "rev-parse" "--is-inside-work-tree"))
+      (let ((output (git-gutter:execute-command
+                     "git" t "rev-parse" "--is-inside-work-tree"))) 
+      (when (and (numberp output)
+                 (zerop output))
         (goto-char (point-min))
-        (looking-at-p "true")))))
+        (looking-at-p "true"))))))
 
 (defun git-gutter:in-repository-common-p (cmd check-subcmd repodir)
   (and (executable-find cmd)


### PR DESCRIPTION
this happen when the base directory is not recognized by git like in
the new emacs-27 feature that allows browsing archives like
/home/foo/foo.zip/foo.txt.

* git-gutter.el (git-gutter:in-git-repository-p): Ensure status of
command is a number before calling zerop on it.