### PR TITLE
Fix live update on files in subdirectories

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -1014,9 +1014,10 @@ start revision."
                (buffer-modified-p)
                (git-gutter:should-update-p))
       (let ((file (file-name-nondirectory it))
+            (root (file-truename (vc-git-root it)))
             (now (make-temp-file "git-gutter-cur"))
             (original (make-temp-file "git-gutter-orig")))
-        (when (git-gutter:write-original-content original file)
+        (when (git-gutter:write-original-content original (file-relative-name it root))
           (git-gutter:write-current-content now)
           (git-gutter:start-live-update file original now))))))
 


### PR DESCRIPTION
`original-file-content` needs to be passed a path relative to the root directory, or else we can't `git show` it, and `write-original-content` fails.  This fix is git specific, but I believe the live update feature already is.

Fixes #146.